### PR TITLE
Minor update to worker movement

### DIFF
--- a/Player.java
+++ b/Player.java
@@ -468,12 +468,17 @@ public class Player {
 					harvested = true;
 					gc.harvest(worker.id(), worker.location().mapLocation().directionTo(karbLoc));
 					karboniteAmts[m][n].changeCount(gc.karboniteAt(karbLoc));
+					System.out.println(playerLocation.distanceSquaredTo(karbLoc));
 				}
 			}
 
 			if(!harvested && karbLoc != null){
-				karboniteCollectionMap = updatePathfindingMap(karbLoc, thisMap);
-				moveAlongBFSPath(gc, worker, karboniteCollectionMap);
+				if (thisPlanet.equals(Planet.Earth) && playerLocation.distanceSquaredTo(karbLoc) > 4) {
+					karboniteCollectionMap = updatePathfindingMap(karbLoc, thisMap);
+					moveAlongBFSPath(gc, worker, karboniteCollectionMap);
+				} else {
+					moveToLoc(gc, worker, karbLoc);
+				}
 			}
 		}
 


### PR DESCRIPTION
Workers on Mars do not use bfs because for some reason it throws null pointer exception. Workers now don't use bfs if karbonite is with 4 distance squared to save time.