### PR TITLE
Minor worker movement update

### DIFF
--- a/Player.java
+++ b/Player.java
@@ -472,8 +472,12 @@ public class Player {
 			}
 
 			if(!harvested && karbLoc != null){
-				karboniteCollectionMap = updatePathfindingMap(karbLoc, thisMap);
-				moveAlongBFSPath(gc, worker, karboniteCollectionMap);
+				if (thisPlanet.equals(Planet.Earth) && playerLocation.distanceSquaredTo(karbLoc) > 4) {
+					karboniteCollectionMap = updatePathfindingMap(karbLoc, thisMap);
+					moveAlongBFSPath(gc, worker, karboniteCollectionMap);
+				} else {
+					moveToLoc(gc, worker, karbLoc);
+				}
 			}
 		}
 


### PR DESCRIPTION
Workers on mars no longer use bfs because it throws Null Pointer Exception for some reason. Workers only use bfs if distance squared to karbonite is > 4